### PR TITLE
Configure fat jar publishing to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply from: 'lib.gradle'
+apply from: 'pom.gradle'
 
 buildscript {
     repositories {
@@ -42,38 +43,10 @@ allprojects {
     publishing {
         publications {
             nexus(MavenPublication) {
-                pom {
-                    name = 'MicroConfig'
-                    description = 'Powerful tool for microservice configuration management'
-                    url = 'https://microconfig.io/'
-                    licenses {
-                        license {
-                            name = 'The Apache License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        }
-                    }
-                    scm {
-                        connection = 'scm:git:https://github.com/microconfig/microconfig.git'
-                        developerConnection = 'scm:git:https://github.com/microconfig/microconfig.git'
-                        url = 'https://microconfig.io'
-                    }
-                    developers {
-                        developer {
-                            id = 'amatorin'
-                            name = 'Alexander Matorin'
-                            email = 'alx.matorin@gmail.com'
-                        }
-                        developer {
-                            id = 'esladkovski'
-                            name = 'Evgeni Sladkovski'
-                            email = 'kapodes@gmail.com'
-                        }
-                        developer {
-                            id = 'apavlov'
-                            name = 'Artem Pavlov'
-                            email = 'admpavlov@yandex.ru'
-                        }
-                    }
+                pom.withXml {
+                    def root = asNode()
+                    root.appendNode('description', pomDescription)
+                    root.children().last() + pomConfig
                 }
                 from components.java
             }

--- a/microconfig/microconfig-core/build.gradle
+++ b/microconfig/microconfig-core/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'application'
+apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 mainClassName = 'io.microconfig.BuildConfigMain'
@@ -7,8 +8,19 @@ publishing {
     publications {
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
+            afterEvaluate {
+                pom.withXml {
+                    def root = asNode()
+                    root.appendNode('description', pomDescription)
+                    root.children().last() + pomConfig
+                }
+            }
         }
     }
+}
+
+signing {
+    sign publishing.publications.shadow
 }
 
 dependencies {

--- a/pom.gradle
+++ b/pom.gradle
@@ -1,0 +1,35 @@
+ext {
+    pomConfig = {
+        name 'MicroConfig'
+        url 'https://microconfig.io/'
+        licenses {
+            license {
+                name 'The Apache License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            }
+        }
+        scm {
+            connection 'scm:git:https://github.com/microconfig/microconfig.git'
+            developerConnection 'scm:git:https://github.com/microconfig/microconfig.git'
+            url 'https://microconfig.io'
+        }
+        developers {
+            developer {
+                id 'amatorin'
+                name 'Alexander Matorin'
+                email 'alx.matorin@gmail.com'
+            }
+            developer {
+                id 'esladkovski'
+                name 'Evgeni Sladkovski'
+                email 'kapodes@gmail.com'
+            }
+            developer {
+                id 'apavlov'
+                name 'Artem Pavlov'
+                email 'admpavlov@yandex.ru'
+            }
+        }
+    }
+    pomDescription = 'Powerful tool for microservice configuration management'
+}


### PR DESCRIPTION
NOTE: Due to release policy of OSSRH, it's not possible to add fat jar to current, 3.12.0, version. 

Closes #12 