### PR TITLE
Add possibility to include custom types from components

### DIFF
--- a/microconfig-core/src/test/java/io/microconfig/core/configtypes/CustomConfigTypeRepositoryTest.java
+++ b/microconfig-core/src/test/java/io/microconfig/core/configtypes/CustomConfigTypeRepositoryTest.java
@@ -3,10 +3,12 @@ package io.microconfig.core.configtypes;
 import io.microconfig.io.DumpedFsReader;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.*;
 
 import static io.microconfig.core.ClasspathReader.classpathFile;
+import static io.microconfig.core.configtypes.ConfigTypeImpl.byNameAndExtensions;
 import static io.microconfig.core.configtypes.CustomConfigTypeRepository.findDescriptorIn;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CustomConfigTypeRepositoryTest {
@@ -17,6 +19,22 @@ class CustomConfigTypeRepositoryTest {
         List<ConfigType> expected = new StandardConfigTypeRepository().getConfigTypes();
         List<ConfigType> actual = customRepo.getConfigTypes();
 
+        checkConfigTypes(expected, actual);
+    }
+
+    @Test
+    void loadTypesUsingIncludeFromFile() {
+        ConfigTypeRepository customRepo = findDescriptorIn(classpathFile("configTypes/withIncludeAndDefault"), new DumpedFsReader());
+
+        List<ConfigType> expected = new ArrayList<>();
+        expected.add(byNameAndExtensions("custom", new HashSet<>(singletonList(".cst")), "result"));
+        expected.addAll(new StandardConfigTypeRepository().getConfigTypes());
+        List<ConfigType> actual = customRepo.getConfigTypes();
+
+        checkConfigTypes(expected, actual);
+    }
+
+    private void checkConfigTypes(List<ConfigType> expected, List<ConfigType> actual) {
         assertEquals(expected.size(), actual.size());
         for (int i = 0; i < expected.size(); i++) {
             ConfigType e = expected.get(i);

--- a/microconfig-core/src/test/resources/configTypes/withIncludeAndDefault/components/types-from-component/microconfig.yaml
+++ b/microconfig-core/src/test/resources/configTypes/withIncludeAndDefault/components/types-from-component/microconfig.yaml
@@ -1,0 +1,5 @@
+configTypes:
+  - custom:
+      resultFileName: result
+      sourceExtensions:
+        - .cst

--- a/microconfig-core/src/test/resources/configTypes/withIncludeAndDefault/microconfig.yaml
+++ b/microconfig-core/src/test/resources/configTypes/withIncludeAndDefault/microconfig.yaml
@@ -1,0 +1,3 @@
+include:
+  - default
+  - types-from-component


### PR DESCRIPTION
Syntax:

microconfig.yaml

```
configTypes:
  - ...
include:
  - default  # add standard config types
  - some-component  # add config types from component "some-component"
```

Component "some-component" has microconfig.yaml with configTypes description